### PR TITLE
do not delete empty arrays in removeKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # deep-cleaner
-Delete nested key-value pairs on an object with a provided key, empty objects, empty strings, null, and undefined values
+Delete nested key-value pairs on an object with a provided key, or remove empty objects, empty strings, null, and undefined values.
 
-### Usage
+## Usage
 
 ```
 cleaner(object[, key])
@@ -9,22 +9,34 @@ cleaner(object[, key])
 #### Arguments
 object (Object): The object to clean.
 
-key (String, optional): The name of the key in a key-value pair you want to delete on the object.
+key (String)\<optional>: The name of the key of a key-value pair you want to recursively remove on `object`
 
 #### Example
 
-To clean empty values,
+To clean empty values:
 
 ```
 var cleaner = require('deep-cleaner');
 
 var obj = {
-  a: 'a',
-  b: '',
-  c: [],
-  d: {},
-  e: null,
-  f: undefined
+  aValue: 'value',
+  emptyString: '',
+  emptyArray: [],
+  emptyObject: {},
+  isNull: null,
+  isUndefined: undefined
+  multiLayeredObj: {
+    anotherValue: 'value',
+    anotherEmptyString: "",
+    anArray: [
+      {
+        noValue: null
+      },
+      {
+        hasValue: 'value'
+      }
+    ]
+  },
 }
 
 cleaner(obj);
@@ -32,7 +44,14 @@ cleaner(obj);
 console.log(obj);
 
 // {
-//   a: 'a'
+//   aValue: 'value',
+//   multiLayeredObj: {
+//      anotherValue: 'value',
+//      anArray: [
+//          {},
+//          {hasValue: 'value'}
+//      ]
+//   }
 // }
 ```
 
@@ -43,10 +62,10 @@ To recursively strip a key-value pair, pass in the name of the key as the second
 var dirtyObject = {
   a: {
     b: {
-      c: "some dirty value"
+      dirty: "value"
     }
   },
-  c: "another dirty value",
+  dirty: "value",
   some_list: [
     {
       dirty: "value",
@@ -63,7 +82,6 @@ var dirtyObject = {
   ]
 }
 
-cleaner(dirtyObject, 'c');
 cleaner(dirtyObject, 'dirty');
 
 console.log(dirtyObject);
@@ -90,17 +108,24 @@ You can also pass in an array of keys to delete, i.e.,
 
 ```
 var obj = {
-  a: 'a',
+  a: {
+    a: 'a',
+    b: 'b'
+  },
   b: 'b',
-  c: 'c'
+  c: 'c',
+  d: 'd'
 }
 
-cleaner(obj, ['a','c']);
+cleaner(obj, ['b','c']);
 
 console.log(obj);
 
 // {
-//   a: 'a'
+//   a: {
+//      a: 'a'
+//   },
+//   d: 'd'
 // }
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/deep-cleaner.svg)](https://badge.fury.io/js/deep-cleaner)
 [![Travis](https://img.shields.io/travis/rust-lang/rust.svg)]()
+[![npm](https://img.shields.io/npm/v/npm.svg)]()
 [![DUB](https://img.shields.io/dub/l/vibe-d.svg)]()
 
 Delete nested key-value pairs on an object with a provided key, or remove empty objects, empty strings, null, and undefined values.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![npm](https://img.shields.io/npm/v/npm.svg)]()
 [![DUB](https://img.shields.io/dub/l/vibe-d.svg)]()
 
-Delete nested key-value pairs on an object with a provided key, or remove empty objects, empty strings, null, and undefined values.
+Light weight packge used to remove empty nested objects, empty strings, null, and undefined values, or removed nested key-value pairs on objects with a given key.
 
-*Note:* A current limitation of this module is it's inability to work on objects containing recursive definitions.
+*Note:* deep-cleaner was designed primarily with JSON in mind. It will not work on objects containing recursive definitions due to it's simplicity.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # deep-cleaner
+
+[![npm version](https://badge.fury.io/js/deep-cleaner.svg)](https://badge.fury.io/js/deep-cleaner)
+[![Travis](https://img.shields.io/travis/rust-lang/rust.svg)]()
+[![DUB](https://img.shields.io/dub/l/vibe-d.svg)]()
+
 Delete nested key-value pairs on an object with a provided key, or remove empty objects, empty strings, null, and undefined values.
+
+## Installation
+
+`npm install --save deep-cleaner`
 
 ## Usage
 
 ```
-cleaner(object[, key])
+deepCleaner(object[, key])
 ```
-#### Arguments
-object (Object): The object to clean.
+#### Arguments:
 
-key (String)\<optional>: The name of the key of a key-value pair you want to recursively remove on `object`
+`object` (Object): The object to clean
 
-#### Example
+`key` (String|Array)\<optional>: The key or array of keys of key-value pairs you want to recursively remove on `object`
 
-To clean empty values:
+## Examples:
+
+To remove empty values (including `undefined` and `null`) on an object:
 
 ```
 var cleaner = require('deep-cleaner');
@@ -55,7 +65,7 @@ console.log(obj);
 // }
 ```
 
-To recursively strip a key-value pair, pass in the name of the key as the second parameter, i.e.,
+To recursively strip a key-value pair, pass in the name of the key as the second parameter:
 
 ```
    
@@ -129,6 +139,7 @@ console.log(obj);
 // }
 
 ```
+## Testing
 
+run `npm test`.
 
-     

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Delete nested key-value pairs on an object with a provided key, or remove empty objects, empty strings, null, and undefined values.
 
+*Note:* A current limitation of this module is it's inability to work on objects containing recursive definitions.
+
 ## Installation
 
 `npm install --save deep-cleaner`

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ var removeElement = (o, i) => o.splice(1, (i - 0));
  */
 function removeKey(o, key) {
   isObject(o) && Object.keys(o).forEach(function (k) {
-    (k === key || o[k] && o[k].length === 0) && delete o[k] ||
+    (k === key) && delete o[k] ||
       (o[k] && isObject(o[k]) && removeKey(o[k], key))
   });
   return o;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-cleaner",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Delete nested key-value pairs on an object with a provided key, or remove undefined, null and empty strings, arrays, and objects.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-cleaner",
-  "version": "1.0.1",
-  "description": "Delete nested key-value pairs on an object with a provided key",
+  "version": "1.1.0",
+  "description": "Delete nested key-value pairs on an object with a provided key, or remove undefined, null and empty strings, arrays, and objects.",
   "main": "index.js",
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,5 @@
     "chai": "^3.5.0",
     "mocha": "^3.2.0"
   },
-  "dependencies": {
-    "lodash": "^4.17.4"
-  }
+  "dependencies": {}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,10 @@ describe('index.js', function () {
                 A: {
                     dirty: 'value',
                     clean: 'value',
+                    emptyNull: null,
+                    emptyUndefined: undefined,
+                    emptyArray: [],
+                    emptyObject: {},
                     a: {
                         dirty: 'value'
                     }
@@ -27,7 +31,20 @@ describe('index.js', function () {
             }
             
             cleaner(actual, 'dirty');
-            expect(actual).to.deep.equal({A: {clean:'value',a:{}},B:[{clean:'value',a:{clean:'value'}}]});
+            expect(actual).to.deep.equal({
+                A: {
+                    clean:'value',
+                    emptyNull: null,
+                    emptyUndefined: undefined,
+                    emptyArray: [],
+                    emptyObject: {},
+                    a:{}
+                },
+                B:[{
+                    clean:'value',
+                    a:{clean:'value'}
+                }]
+            });
             done();
         });
 


### PR DESCRIPTION
Fixes #1 

Was there a reason for deleting empty arrays in the `removeKey` func ? This fixes it, also added tests to validate that empty values are kept when deleting specific keys.